### PR TITLE
Add IaaS credentials note regarding user privileges

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -46,6 +46,12 @@ However, the value structures, e.g. JSON configuration strings, might differ.
 Example values are provided for AWS and vSphere.
 If your infrastructure type is missing, contact <a href="mailto:svc.support@anynines.com">anynines Support</a>.
 
+<p class="note">
+The IaaS credentials you are going to specify in this Settings needs to have the privileges
+described in the <a href="http://docs.pivotal.io/pivotalcf/1-8/customizing/requirements.html" target="_blank">
+Prerequisites to Deploying Operations Manager and Elastic Runtime</a> documentation.
+</p>
+
 If you are using AWS, see [AWS-specific Settings](#aws-config).
 
 If you are using vSphere, see [vSphere-specific Settings](#vsphere-config).


### PR DESCRIPTION
Hello @jncd and @bentarnoff,

@wolfoo2931 have been made aware by Jacques Malan of a missing information in the documentation that would prevent users to be able to use the Tile properly.

We forgot to tell the users which privileges should be granted by the IaaS crendentials that the user have to fill.

This PR adds a note explaining this and sending the user to the Ops Mgr and ER documentation.